### PR TITLE
pass $nomad::init_style

### DIFF
--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -12,9 +12,10 @@ class nomad::run_service {
 
   if $nomad::manage_service == true {
     service { 'nomad':
-      ensure => $nomad::service_ensure,
-      name   => $init_selector,
-      enable => $nomad::service_enable,
+      ensure   => $nomad::service_ensure,
+      name     => $init_selector,
+      enable   => $nomad::service_enable,
+      provider => $nomad::init_style,
     }
   }
 


### PR DESCRIPTION
this fixes the nomad service not properly being initialized in ubuntu 15.04
